### PR TITLE
Adapt app to new DB schema

### DIFF
--- a/app/api/admin/reports/recent/route.ts
+++ b/app/api/admin/reports/recent/route.ts
@@ -7,13 +7,12 @@ export async function GET(request: NextRequest) {
     
     try {
       const [reports] = await connection.execute(`
-        SELECT 
-          r.id, 
-          r.user_id, 
-          r.address, 
+        SELECT
+          r.id,
+          r.user_id,
+          r.address,
           r.description,
-          r.status,
-          r.created_at, 
+          r.created_at,
           u.name as user_name
         FROM reports r
         LEFT JOIN users u ON r.user_id = u.id
@@ -27,7 +26,9 @@ export async function GET(request: NextRequest) {
         user_id: report.user_id,
         address: report.address,
         description: report.description,
-        status: report.status || 'pending', // Default status if null
+        // The current database does not include a status column
+        // Default all reports to 'pending' for compatibility
+        status: 'pending',
         created_at: report.created_at,
         user: {
           name: report.user_name || 'Unknown User'

--- a/app/api/admin/reports/route.ts
+++ b/app/api/admin/reports/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest) {
     
     try {
       const [reports] = await connection.execute(`
-        SELECT r.id, r.user_id, r.address, r.created_at, u.name as user_name
+        SELECT r.id, r.user_id, r.address, r.description, r.created_at, u.name as user_name
         FROM reports r
         JOIN users u ON r.user_id = u.id
         ORDER BY r.created_at DESC
@@ -18,6 +18,7 @@ export async function GET(request: NextRequest) {
         id: report.id,
         user_id: report.user_id,
         address: report.address,
+        description: report.description,
         created_at: report.created_at,
         user: {
           name: report.user_name

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -110,24 +110,11 @@ export async function GET(request: NextRequest) {
         userChange = 100;
       }
       
-      // Get report status counts
-      const [pendingResult] = await connection.execute(
-        'SELECT COUNT(*) as count FROM reports WHERE status = ?',
-        ['pending']
-      );
-      const pending = (pendingResult as any[])[0].count;
-      
-      const [processingResult] = await connection.execute(
-        'SELECT COUNT(*) as count FROM reports WHERE status = ?',
-        ['processing']
-      );
-      const processing = (processingResult as any[])[0].count;
-      
-      const [completedResult] = await connection.execute(
-        'SELECT COUNT(*) as count FROM reports WHERE status = ?',
-        ['completed']
-      );
-      const completed = (completedResult as any[])[0].count;
+      // The current schema does not include a status column on reports.
+      // Provide default status counts for compatibility with existing UI.
+      const pending = totalReports;
+      const processing = 0;
+      const completed = 0;
       
       // Get monthly reports count
       const thisMonth = new Date();

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -62,7 +62,13 @@ export default function ReportsPage() {
       const response = await fetch('/api/admin/reports');
       if (response.ok) {
         const data = await response.json();
-        setReports(data);
+        // Ensure backward compatibility when the API
+        // does not provide a status field
+        const normalized = data.map((r: any) => ({
+          ...r,
+          status: r.status || 'pending'
+        }));
+        setReports(normalized);
       } else {
         console.error('Failed to fetch reports');
       }

--- a/components/admin/DashboardStats.tsx
+++ b/components/admin/DashboardStats.tsx
@@ -372,7 +372,9 @@ export default function DashboardStats({ stats: propStats, useMockData = false }
               </TableHead>
               <TableBody>
                 {recentReports && recentReports.length > 0 ? (
-                  recentReports.slice(0, 5).map((report: any) => (
+                  recentReports.slice(0, 5).map((report: any) => {
+                    const status = report.status || 'pending';
+                    return (
                     <TableRow key={report.id} hover sx={{ '&:hover': { bgcolor: alpha(theme.palette.primary.main, 0.04) } }}>
                       <TableCell sx={{ py: 2, fontSize: '0.9rem' }}>#{report.id}</TableCell>
                       <TableCell sx={{ py: 2, fontSize: '0.9rem' }}>{report.user?.name}</TableCell>
@@ -394,19 +396,20 @@ export default function DashboardStats({ stats: propStats, useMockData = false }
                       </TableCell>
                       <TableCell sx={{ py: 2 }}>
                         <Chip
-                          label={getStatusLabel(report.status)}
+                          label={getStatusLabel(status)}
                           size="small"
                           sx={{
                             height: 28,
                             fontSize: '0.8rem',
                             fontWeight: 600,
-                            backgroundColor: alpha(getStatusColor(report.status), 0.1),
-                            color: getStatusColor(report.status),
+                            backgroundColor: alpha(getStatusColor(status), 0.1),
+                            color: getStatusColor(status),
                           }}
                         />
                       </TableCell>
                     </TableRow>
-                  ))
+                  );
+                  })
                 ) : (
                   <TableRow>
                     <TableCell colSpan={5} align="center" sx={{ py: 4 }}>


### PR DESCRIPTION
## Summary
- update report API to include `description` and default `status`
- adjust stats API for lack of `status` column
- normalize reports on the reports page
- align dashboard recent reports table style

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npx tsc --noEmit` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866870276e88320b58c080195e1c360